### PR TITLE
IMPORTANT: Removed the search box the JD CS

### DIFF
--- a/lib/cs/home.html
+++ b/lib/cs/home.html
@@ -53,7 +53,7 @@ cmCreatePageviewTag("CUSTOMER SERVICE: HOME", "CUSTOMER SERVICE", null, null, 10
     <div id="content-responsive">
     	<div class="content">
 
-            <div id="search-container">
+            <!--<div id="search-container">
             <div id="searchBox">
             <h2>Find Your Answer</h2>
 				
@@ -68,7 +68,7 @@ cmCreatePageviewTag("CUSTOMER SERVICE: HOME", "CUSTOMER SERVICE", null, null, 10
             </div>
 				
 
-            </div>
+            </div>-->
             <ul id="quickThumbs">
                 <li class="thumb_faq"><a href="faqs.html"><span>FAQs</span></a></li>
                 <li class="thumb_contact"><a href="contact-us.html"><span>Contact Us</span></a></li>


### PR DESCRIPTION
Removed the search box the JD customer services page. This is due to
the GET in the search is not supported in the IFRAME call via the URL
on the faqs.html which appends the iFRAME via jQuery..